### PR TITLE
Add support for Rails 5

### DIFF
--- a/bootstrap-tabdrop-rails.gemspec
+++ b/bootstrap-tabdrop-rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "railties", "~> 4"
+  spec.add_dependency "railties", ">= 4"
 end

--- a/lib/bootstrap/tabdrop/rails/version.rb
+++ b/lib/bootstrap/tabdrop/rails/version.rb
@@ -1,7 +1,7 @@
 module Bootstrap
   module Tabdrop
     module Rails
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
     end
   end
 end


### PR DESCRIPTION
Relax railties dependency version to support Rails 5.

We're using this in production on Rails 5.1.6 and everything seems to work fine.